### PR TITLE
Change enum identifiers for C++ compatibility

### DIFF
--- a/tmc2130.h
+++ b/tmc2130.h
@@ -119,7 +119,7 @@ typedef enum {
 
 typedef uint8_t tmc2130_regaddr_t;
 
-enum tmc2130_regaddr_t {
+enum tmc2130_regaddr {
     TMC2130Reg_GCONF        = 0x00,
     TMC2130Reg_GSTAT        = 0x01,
     TMC2130Reg_IOIN         = 0x04,

--- a/tmc2209.h
+++ b/tmc2209.h
@@ -117,7 +117,7 @@ typedef enum {
 
 typedef uint8_t tmc2209_regaddr_t;
 
-enum tmc2209_regaddr_t {
+enum tmc2209_regaddr {
     TMC2209Reg_GCONF        = 0x00,
     TMC2209Reg_GSTAT        = 0x01,
     TMC2209Reg_IFCNT        = 0x02,

--- a/tmc2660.h
+++ b/tmc2660.h
@@ -104,7 +104,7 @@ typedef enum {
 typedef uint8_t tmc2660_regaddr_t;
 
 //adresses are 3 bits.
-enum tmc2660_regaddr_t {
+enum tmc2660_regaddr {
     TMC2660Reg_DRVCTRL  = 0b000, // only ever going to use step/dir mode.
     TMC2660Reg_CHOPCONF = 0b100,
     TMC2660Reg_SMARTEN  = 0b101, // Coolstep control register.

--- a/tmc5160.h
+++ b/tmc5160.h
@@ -121,7 +121,7 @@ typedef enum {
 
 typedef uint8_t tmc5160_regaddr_t;
 
-enum tmc5160_regaddr_t {
+enum tmc5160_regaddr {
     TMC5160Reg_GCONF            = 0x00,
     TMC5160Reg_GSTAT            = 0x01,
     TMC5160Reg_IFCNT            = 0x02,


### PR DESCRIPTION
Hi,
I use the library for a C++ project. When compiling I get an error because the identifier of the enum (`tmcXXXX_regaddr_t`) is the same as the name of the type in the line directly before it.

In C the identifier of an enum is irrelevant (except for clarity), but in C++ it is relevant. By changing the identifier, it is also possible to use the library with a C++ compiler.
Despite the change, it is still clear that these are the addresses and that they are used with the type `tmcXXXX_regaddr_t`.

Since the affected files are header files, it is not possible to specifically compile the affected file with a C compiler.

jjw2202